### PR TITLE
Add preserve-indent command line directive

### DIFF
--- a/src/main/java/com/igormaznitsa/jcp/JCPreprocessor.java
+++ b/src/main/java/com/igormaznitsa/jcp/JCPreprocessor.java
@@ -77,7 +77,8 @@ public final class JCPreprocessor {
     new VerboseHandler(),
     new GlobalVariableDefiningFileHandler(),
     new GlobalVariableHandler(),
-    new CareForLastNextLineCharHandler()
+    new CareForLastNextLineCharHandler(),
+    new PreserveIndentDirectiveHandler(),
   };
 
   @Nonnull

--- a/src/main/java/com/igormaznitsa/jcp/cmdline/PreserveIndentDirectiveHandler.java
+++ b/src/main/java/com/igormaznitsa/jcp/cmdline/PreserveIndentDirectiveHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014 Igor Maznitsa (http://www.igormaznitsa.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.igormaznitsa.jcp.cmdline;
+
+import javax.annotation.Nonnull;
+
+import com.igormaznitsa.jcp.context.PreprocessorContext;
+
+/**
+ * Preserve indent when removing line-prefixes "//$" and "//$$"
+ *
+ */
+public class PreserveIndentDirectiveHandler implements CommandLineHandler {
+
+  private static final String ARG_NAME = "/PI";
+
+  @Override
+  @Nonnull
+  public String getDescription() {
+    return "turn on mode to preserve indent when removing //$ and //$$";
+  }
+
+  @Override
+  public boolean processCommandLineKey(@Nonnull final String key, @Nonnull final PreprocessorContext context) {
+    boolean result = false;
+
+    if (ARG_NAME.equalsIgnoreCase(key)) {
+      context.setPreserveIndent(true);
+      result = true;
+    }
+
+    return result;
+  }
+
+  @Override
+  @Nonnull
+  public String getKeyName() {
+    return ARG_NAME;
+  }
+
+}

--- a/src/main/java/com/igormaznitsa/jcp/containers/FileInfoContainer.java
+++ b/src/main/java/com/igormaznitsa/jcp/containers/FileInfoContainer.java
@@ -235,30 +235,44 @@ public class FileInfoContainer {
 
   @Nonnull
   private String extractDoubleDollarPrefixedDirective(@Nonnull final String line, @Nonnull final PreprocessorContext context) {
+    String r = null;
     if (context.isAllowWhitespace()) {
       final Matcher matcher = DIRECTIVE_TWO_DOLLARS_PREFIXED.matcher(line);
       if (matcher.find()) {
-        return matcher.group(1);
+        r = matcher.group(1);
       } else {
         throw new Error("Unexpected situation, '//$$' directive is not found, contact developer! (" + line + ')');
       }
     } else {
-      return PreprocessorUtils.extractTail("//$$", line);
+      r = PreprocessorUtils.extractTail("//$$", line);
     }
+    if (context.isPreserveIndent()) {
+      int indentLength = line.indexOf("$$") + "$$".length();
+      String indent = new String(new char[indentLength]).replace("\0", " ");
+      return indent + r;
+    }
+    return r;
   }
 
   @Nonnull
   private String extractSingleDollarPrefixedDirective(@Nonnull final String line, @Nonnull final PreprocessorContext context) {
+    String r = null;
     if (context.isAllowWhitespace()) {
       final Matcher matcher = DIRECTIVE_SINGLE_DOLLAR_PREFIXED.matcher(line);
       if (matcher.find()) {
-        return matcher.group(1);
+        r = matcher.group(1);
       } else {
         throw new Error("Unexpected situation, '//$' directive is not found, contact developer! (" + line + ')');
       }
     } else {
-      return PreprocessorUtils.extractTail("//$", line);
+      r = PreprocessorUtils.extractTail("//$", line);
     }
+    if (context.isPreserveIndent()) {
+      int indentLength = line.indexOf("$")+"$".length();
+      String indent = new String(new char[indentLength]).replace("\0", " ");
+      return indent + r;
+    }
+    return r;
   }
 
   /**

--- a/src/main/java/com/igormaznitsa/jcp/context/PreprocessorContext.java
+++ b/src/main/java/com/igormaznitsa/jcp/context/PreprocessorContext.java
@@ -58,7 +58,8 @@ public final class PreprocessorContext {
   private boolean keepNonExecutingLines = false;
   private boolean careForLastNextLine = false;
   private boolean compareDestination = false;
-  private boolean allowWhitespace=false;
+  private boolean allowWhitespace = false;
+  private boolean preserveIndent = false;
 
   private String sourceDirectories;
   private String destinationDirectory;
@@ -132,6 +133,7 @@ public final class PreprocessorContext {
     this.fileOutputDisabled = context.fileOutputDisabled;
     this.keepNonExecutingLines = context.keepNonExecutingLines;
     this.allowWhitespace = context.allowWhitespace;
+    this.preserveIndent = context.preserveIndent;
     this.sourceDirectories = context.sourceDirectories;
     this.destinationDirectory = context.destinationDirectory;
     this.destinationDirectoryFile = context.destinationDirectoryFile;
@@ -291,6 +293,23 @@ public final class PreprocessorContext {
     return this.allowWhitespace;
   }
   
+  /**
+   * Set flag to control whether prefixes "//$", "//$$" should replaced
+   * with equal length whitespace strings rather than just removed.
+   * @param flag true enables preserve-indent, false disables it
+   */
+  public void setPreserveIndent(final boolean flag){
+    this.preserveIndent = flag;
+  }
+
+  /**
+   * Get flag indicating whether preserve-indent is enabled or disabled.
+   * @return true if preserve-indent is enabled, false otherwise
+   */
+  public boolean isPreserveIndent() {
+    return this.preserveIndent;
+  }
+
   /**
    * Set source directories
    *


### PR DESCRIPTION
Use /PI to tell JCP to preserve line indentation when processing
line-prefixes //$ and //$$.  When /PI is specified, then "//$" gets
replaced with three spaces, and "//$$" gets replaced with four spaces.