### PR TITLE
add exclude-git command line directive

### DIFF
--- a/src/main/java/com/igormaznitsa/jcp/JCPreprocessor.java
+++ b/src/main/java/com/igormaznitsa/jcp/JCPreprocessor.java
@@ -79,6 +79,7 @@ public final class JCPreprocessor {
     new GlobalVariableHandler(),
     new CareForLastNextLineCharHandler(),
     new PreserveIndentDirectiveHandler(),
+    new ExcludeGitDirectiveHandler(),
   };
 
   @Nonnull
@@ -235,6 +236,10 @@ public final class JCPreprocessor {
     final Collection<FileInfoContainer> result = new ArrayList<FileInfoContainer>();
 
     for (final File dir : srcDirs) {
+      if (dir.getName().equals(".git") && context.isExcludeGit()) {
+        continue;
+      }
+
       final String canonicalPathForSrcDirectory = dir.getCanonicalPath();
       final Set<File> allFoundFiles = findAllFiles(dir);
 
@@ -262,6 +267,9 @@ public final class JCPreprocessor {
     final File[] allowedFiles = dir.listFiles();
     for (final File file : allowedFiles) {
       if (file.isDirectory()) {
+        if (file.getName().equals(".git") && context.isExcludeGit()) {
+          continue;
+        }
         result.addAll(findAllFiles(file));
       } else {
         result.add(file);

--- a/src/main/java/com/igormaznitsa/jcp/cmdline/ExcludeGitDirectiveHandler.java
+++ b/src/main/java/com/igormaznitsa/jcp/cmdline/ExcludeGitDirectiveHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014 Igor Maznitsa (http://www.igormaznitsa.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.igormaznitsa.jcp.cmdline;
+
+import javax.annotation.Nonnull;
+
+import com.igormaznitsa.jcp.context.PreprocessorContext;
+
+/**
+ * Exclude processing of ".git" directories
+ *
+ */
+public class ExcludeGitDirectiveHandler implements CommandLineHandler {
+
+  private static final String ARG_NAME = "/EG";
+
+  @Override
+  @Nonnull
+  public String getDescription() {
+    return "turn on mode to exclude processing of \".git\" directories";
+  }
+
+  @Override
+  public boolean processCommandLineKey(@Nonnull final String key, @Nonnull final PreprocessorContext context) {
+    boolean result = false;
+
+    if (ARG_NAME.equalsIgnoreCase(key)) {
+      context.setExcludeGit(true);
+      result = true;
+    }
+
+    return result;
+  }
+
+  @Override
+  @Nonnull
+  public String getKeyName() {
+    return ARG_NAME;
+  }
+
+}

--- a/src/main/java/com/igormaznitsa/jcp/context/PreprocessorContext.java
+++ b/src/main/java/com/igormaznitsa/jcp/context/PreprocessorContext.java
@@ -60,6 +60,7 @@ public final class PreprocessorContext {
   private boolean compareDestination = false;
   private boolean allowWhitespace = false;
   private boolean preserveIndent = false;
+  private boolean excludeGit = false;
 
   private String sourceDirectories;
   private String destinationDirectory;
@@ -134,6 +135,7 @@ public final class PreprocessorContext {
     this.keepNonExecutingLines = context.keepNonExecutingLines;
     this.allowWhitespace = context.allowWhitespace;
     this.preserveIndent = context.preserveIndent;
+    this.excludeGit = context.excludeGit;
     this.sourceDirectories = context.sourceDirectories;
     this.destinationDirectory = context.destinationDirectory;
     this.destinationDirectoryFile = context.destinationDirectoryFile;
@@ -308,6 +310,23 @@ public final class PreprocessorContext {
    */
   public boolean isPreserveIndent() {
     return this.preserveIndent;
+  }
+
+  /**
+   * Set flag to control whether processing of ".git" directories
+   * is excluded.
+   * @param flag true skips ".git" directories, false does not skip them
+   */
+  public void setExcludeGit(final boolean flag){
+    this.excludeGit = flag;
+  }
+
+  /**
+   * Get flag indicating whether exclude-git is enabled or disabled.
+   * @return true if exclude-git is enabled, false otherwise
+   */
+  public boolean isExcludeGit() {
+    return this.excludeGit;
   }
 
   /**


### PR DESCRIPTION
Use /EG to tell JCP to exclude the contents of ".git" directories from the files it processes.

This is useful for speeding up JCP (because fewer files are scanned), and, more importantly, it keeps JCP from crashing when processing git projects inside an android development tree.

Here is an example crash:

```
$ jcp /C /I:android-7.x/frameworks/opt/telephony /O:~/tmp/jcp/frameworks/opt/telephony
Java Comment Preprocessor v6.0.0
Project page: http://java-comment-preprocessor.googlecode.com/
2003-2014 Author: Igor A. Maznitsa (igor.maznitsa@igormaznitsa.com)
android-7.x/frameworks/opt/telephony/.git/shallow (No such file or directory)
java.io.FileNotFoundException: android-7.x/frameworks/opt/telephony/.git/shallow (No such file or directory)
        at java.io.FileInputStream.open0(Native Method)
        at java.io.FileInputStream.open(FileInputStream.java:195)
        at java.io.FileInputStream.<init>(FileInputStream.java:138)
        at com.igormaznitsa.jcp.utils.PreprocessorUtils.copyFile(PreprocessorUtils.java:147)
        at com.igormaznitsa.jcp.JCPreprocessor.preprocessFiles(JCPreprocessor.java:168)
        at com.igormaznitsa.jcp.JCPreprocessor.execute(JCPreprocessor.java:100)
        at com.igormaznitsa.jcp.JCPreprocessor.main(JCPreprocessor.java:265)
```

To be fair, the crash isn't JCP's fault.  It happens because of the way the `repo` tool populates the android dev tree with git projects (`.git/shallow` is a broken sym-link).  `/EG` is just a way of accommodating repo's behaviour.


