### PR TITLE
Make use of dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
I've set up dependabot so that you automatically receive pull requests when a new version of a dependency is available. You can of course set it to be weekly or monthly.